### PR TITLE
fix: respect minimum_differential constraint between cooling/heating setpoints

### DIFF
--- a/custom_components/daikin_brc1h/climate.py
+++ b/custom_components/daikin_brc1h/climate.py
@@ -273,11 +273,44 @@ class IntegrationKadomaClimate(IntegrationKadomaEntity, ClimateEntity):
 
         return temp
 
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the current temperature from the indoor sensor."""
+        sensors = self.coordinator.data.get("sensors")
+        if sensors is None:
+            return None
+        return sensors.get("indoor")
+
     async def async_set_temperature(self, *, temperature: float, **kwargs) -> None:
         temperature = round(temperature)
 
-        await self.unit.set_point.update(cooling=temperature, heating=temperature)
+        # The device enforces cooling_setpoint >= heating_setpoint + 1°C
+        # (minimum_differential field 0x32 in the setpoint BLE response, value 0x01).
+        # Setting both to the same value causes the device to silently reject the
+        # change that would violate the constraint, resulting in no visible update.
+        # Fix: keep the inactive setpoint 1°C away from the target.
+        operation_mode = self.coordinator.data.get("operation_mode")
+        set_point = self.unit.set_point
+
+        if operation_mode is kadoma.OperationModeValue.HEAT:
+            new_heating = temperature
+            new_cooling = temperature + 1
+        else:
+            # COOL mode (and AUTO/DRY fallback)
+            new_cooling = temperature
+            new_heating = temperature - 1
+
+        await set_point._send(  # noqa: SLF001
+            set_point.UPDATE_CMD_ID,
+            {
+                "cooling_set_point": set_point.convert_to_device(new_cooling),
+                "heating_set_point": set_point.convert_to_device(new_heating),
+            },
+        )
         self.coordinator.data["set_point"].update(
-            {"cooling_set_point": temperature, "heating_set_point": temperature}
+            {
+                "cooling_set_point": new_cooling,
+                "heating_set_point": new_heating,
+            }
         )
         self.async_write_ha_state()


### PR DESCRIPTION
## Problem

When calling `climate.set_temperature`, the thermostat silently ignores the command and reverts to the original value after a few seconds.

## Root cause

The BRC1H device enforces a **minimum differential of 1°C** between `cooling_setpoint` and `heating_setpoint` (field `0x32` in the setpoint BLE response, value `0x01`).

The original code set both setpoints to the same target temperature:

```python
await self.unit.set_point.update(cooling=temperature, heating=temperature)
```

When the device receives `cooling=N, heating=N`, it rejects whichever change would violate `cooling >= heating + 1`, resulting in no change on the physical thermostat.

This can be confirmed in the BLE status response:
```
recv: ...32:01:01...  ← 0x32 = minimum_differential = 1°C
```

## Fix

Send the two setpoints with the required 1°C gap, based on the active mode:

- **COOL mode**: `cooling=target`, `heating=target-1`
- **HEAT mode**: `heating=target`, `cooling=target+1`

## Additional fix

Adds `current_temperature` property that reads `sensors.indoor` from the coordinator data. The coordinator already fetches this value via `SensorsKnob` but the climate entity never exposed it to Home Assistant, so the thermostat card always showed `unknown` for current temperature.

## Testing

Tested on a BRC1H device (Daikin Madoka). Before the fix, temperature could only be raised (never lowered) by one degree at a time. After the fix, both raising and lowering work correctly in 1°C increments.